### PR TITLE
Add health check

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,11 +21,16 @@ const (
 
 // Config for wal-listener.
 type Config struct {
-	Listener   *ListenerCfg  `valid:"required"`
-	Database   *DatabaseCfg  `valid:"required"`
-	Publisher  *PublisherCfg `valid:"required"`
-	Logger     *cfg.Logger   `valid:"required"`
-	Monitoring cfg.Monitoring
+	Listener    *ListenerCfg  `valid:"required"`
+	Database    *DatabaseCfg  `valid:"required"`
+	Publisher   *PublisherCfg `valid:"required"`
+	Logger      *cfg.Logger   `valid:"required"`
+	HealthCheck *HealthCheckCfg
+	Monitoring  cfg.Monitoring
+}
+
+type HealthCheckCfg struct {
+	Port int `valid:"required"`
 }
 
 // ListenerCfg path of the listener config.

--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -103,14 +103,14 @@ func TestListener_slotIsExists(t *testing.T) {
 				repository: repo,
 			}
 
-			got, err := w.slotIsExists()
+			got, err := w.slotExists()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("slotIsExists() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("slotExists() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			if got != tt.want {
-				t.Errorf("slotIsExists() got = %v, want %v", got, tt.want)
+				t.Errorf("slotExists() got = %v, want %v", got, tt.want)
 			}
 
 			repo.AssertExpectations(t)


### PR DESCRIPTION
A proposal to solve https://github.com/ihippik/wal-listener/issues/31

The code does get a little more complicated, but running start up activities asynchronously is more or less a requirement for Kubernetes, as the app is expected to respond to alive-probes (but not necessarily ready-probes) at once. The general structure is one I have used in other projects, and it works well.

PR also adds optional config - the health check server is only started if the config is there. 

There is perhaps some inconsistency in how log messages are formated now, but perhaps that does not matter?