### PR TITLE
Fix LSN not correctly updated

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -378,6 +378,7 @@ func (l *Listener) processMessage(ctx context.Context, msg *pgx.ReplicationMessa
 
 func (l *Listener) processHeartBeat(msg *pgx.ReplicationMessage) {
 	if msg.ServerHeartbeat == nil {
+		l.log.Debug("empty server heartbeat message")
 		return
 	}
 
@@ -386,6 +387,10 @@ func (l *Listener) processHeartBeat(msg *pgx.ReplicationMessage) {
 		slog.Uint64("server_wal_end", msg.ServerHeartbeat.ServerWalEnd),
 		slog.Uint64("server_time", msg.ServerHeartbeat.ServerTime),
 	)
+
+	if msg.ServerHeartbeat.ServerWalEnd > l.readLSN() {
+		l.setLSN(msg.ServerHeartbeat.ServerWalEnd)
+	}
 
 	if msg.ServerHeartbeat.ReplyRequested == 1 {
 		l.log.Debug("status requested")


### PR DESCRIPTION
Before this change, the LSN indicated in the server heartbeat was not used to in the status reply, leading to the logical replication being delayed at least by 1 change. The issue did not have an impact on the data being received from the replication but it was an issue when trying to stop the PostgreSQL server, as it will wait for the replication to be up to date before shutting down.

In my case, it prevented the PostgreSQL server to shut down completely, which is not great in a HA fashion.

The issue can be easily reproduced by starting this project and noticing on PostgreSQL using `select * from pg_stat_replication;` that the `sent_lsn` and `write_lsn` differs. Also trying to shut down using `pg_ctl` will lead to a `pg_ctl: server does not shut down` unless `wal-listener` is stopped in between.

This commits is inspired by what is done in the [`pglogrepl` project](https://github.com/jackc/pglogrepl) (which is the "replication" part of `pgx`), in the logical replication example : https://github.com/jackc/pglogrepl/blob/master/example/pglogrepl_demo/main.go#L128