### PR TITLE
Raise an error if the replication slot is alive

### DIFF
--- a/listener/errors.go
+++ b/listener/errors.go
@@ -10,4 +10,5 @@ var (
 	errEmptyWALMessage      = errors.New("empty WAL message")
 	errUnknownMessageType   = errors.New("unknown message type")
 	errRelationNotFound     = errors.New("relation not found")
+	errReplDidNotStart      = errors.New("replication did not start")
 )

--- a/listener/repository.go
+++ b/listener/repository.go
@@ -54,3 +54,17 @@ func (r RepositoryImpl) IsAlive() bool {
 func (r RepositoryImpl) Close() error {
 	return r.conn.Close()
 }
+
+// IsReplicationActive returns true if the replication slot is already active, false otherwise.
+func (r RepositoryImpl) IsReplicationActive(slotName string) (bool, error) {
+	var activePID int
+
+	err := r.conn.QueryRow("SELECT active_pid FROM pg_replication_slots WHERE slot_name=$1 AND active=true;", slotName).
+		Scan(&activePID)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+
+	return true, err
+}

--- a/listener/repository_mock_test.go
+++ b/listener/repository_mock_test.go
@@ -31,3 +31,8 @@ func (r *repositoryMock) NewStandbyStatus(walPositions ...uint64) (status *pgx.S
 	args := r.Called(walPositions)
 	return args.Get(0).(*pgx.StandbyStatus), args.Error(1)
 }
+
+func (r *repositoryMock) IsReplicationActive(slotName string) (bool, error) {
+	args := r.Called(slotName)
+	return args.Bool(0), args.Error(1)
+}


### PR DESCRIPTION
Before this change the listener could get forever stuck doing nothing since `StartReplication()` does not raise an error if the replication slot is already active. Added `IsReplicationActive()` to the repository to check it before starting the stream.