### PR TITLE
Fix instanciation of errgroup

### DIFF
--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -221,7 +221,7 @@ func (l *Listener) Process(ctx context.Context) error {
 		return errReplDidNotStart
 	}
 
-	group := new(errgroup.Group)
+	group, ctx := errgroup.WithContext(ctx)
 
 	group.Go(func() error {
 		return l.Stream(ctx)


### PR DESCRIPTION
Current implementation does not use the dedicated context that `errgroup.WithContext()` returns, leading to the possibility of the process endlessly stuck doing nothing since `group.Wait()` will not return unless all goroutines return.