### PR TITLE
feat(rabbitmq): make exchange kind configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ the name of the database, and the name of the table `prefix + schema_table`.
 > which will indicate from which table field to take the key.
 > If there is no such field, the table name will be used.
 
+> If you are using RabbitMQ, you must specify the **exchangeKind** config variable as [ *fanout* / *topic* / *direct* ]
+
 
 ```go
 {

--- a/cmd/wal-listener/init.go
+++ b/cmd/wal-listener/init.go
@@ -132,12 +132,12 @@ func factoryPublisher(ctx context.Context, cfg *config.PublisherCfg, logger *slo
 			return nil, fmt.Errorf("new connection: %w", err)
 		}
 
-		p, err := publisher.NewPublisher(cfg.Topic, conn)
+		p, err := publisher.NewPublisher(cfg.Topic, cfg.ExchangeKind, conn)
 		if err != nil {
 			return nil, fmt.Errorf("new publisher: %w", err)
 		}
 
-		pub, err := publisher.NewRabbitPublisher(cfg.Topic, conn, p)
+		pub, err := publisher.NewRabbitPublisher(cfg.Topic, cfg.ExchangeKind, conn, p)
 		if err != nil {
 			return nil, fmt.Errorf("new rabbit publisher: %w", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -75,6 +76,8 @@ type FilterStruct struct {
 	Tables map[string][]string
 }
 
+var errExchangeKindRequired = errors.New("publisher.exchangeKind is required for RabbitMQ publisher")
+
 // Validate config data.
 func (c Config) Validate() error {
 	_, err := govalidator.ValidateStruct(c)
@@ -83,13 +86,13 @@ func (c Config) Validate() error {
 	}
 
 	if c.Publisher != nil && c.Publisher.Type == PublisherTypeRabbitMQ && c.Publisher.ExchangeKind == "" {
-		return fmt.Errorf("publisher.exchange_kind is required for rabbitmq publisher")
+		return errExchangeKindRequired
 	}
 
 	return nil
 }
 
-// InitConfig load config from file.
+// InitConfig load config from a file.
 func InitConfig(path string) (*Config, error) {
 	const envPrefix = "WAL"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type PublisherCfg struct {
 	MessageKeyFrom  string
 	Address         string
 	Topic           string `valid:"required"`
+	ExchangeKind    string
 	TopicPrefix     string
 	EnableTLS       bool
 	ClientCert      string
@@ -77,7 +78,15 @@ type FilterStruct struct {
 // Validate config data.
 func (c Config) Validate() error {
 	_, err := govalidator.ValidateStruct(c)
-	return err
+	if err != nil {
+		return err
+	}
+
+	if c.Publisher != nil && c.Publisher.Type == PublisherTypeRabbitMQ && c.Publisher.ExchangeKind == "" {
+		return fmt.Errorf("publisher.exchange_kind is required for rabbitmq publisher")
+	}
+
+	return nil
 }
 
 // InitConfig load config from file.

--- a/internal/publisher/rabbit.go
+++ b/internal/publisher/rabbit.go
@@ -145,11 +145,6 @@ func NewPublisher(topic, exchangeKind string, conn *amqp.Connection) (*amqp.Chan
 		return nil, fmt.Errorf("open channel: %w", err)
 	}
 
-	if exchangeKind == "" {
-		_ = channel.Close()
-		return nil, fmt.Errorf("exchange kind is required")
-	}
-
 	if err = channel.ExchangeDeclare(
 		topic,
 		exchangeKind,

--- a/internal/publisher/rabbit.go
+++ b/internal/publisher/rabbit.go
@@ -15,23 +15,30 @@ import (
 
 // RabbitPublisher represent event publisher for RabbitMQ.
 type RabbitPublisher struct {
-	pt      string
-	conn    *amqp.Connection
-	channel *amqp.Channel
-	mu      sync.Mutex
-	alive   atomic.Bool
+	pt           string
+	exchangeKind string
+	conn         *amqp.Connection
+	channel      *amqp.Channel
+	mu           sync.Mutex
+	alive        atomic.Bool
 }
 
 // NewRabbitPublisher create new RabbitPublisher instance.
 func NewRabbitPublisher(
 	pubTopic string,
+	exchangeKind string,
 	conn *amqp.Connection,
 	channel *amqp.Channel,
 ) (*RabbitPublisher, error) {
+	if exchangeKind == "" {
+		return nil, fmt.Errorf("exchange kind is required")
+	}
+
 	p := &RabbitPublisher{
-		pt:      pubTopic,
-		conn:    conn,
-		channel: channel,
+		pt:           pubTopic,
+		exchangeKind: exchangeKind,
+		conn:         conn,
+		channel:      channel,
 	}
 	p.alive.Store(true)
 
@@ -90,7 +97,7 @@ func (p *RabbitPublisher) CheckHealth(_ context.Context) error {
 	// Passive declaration validates exchange availability over current channel.
 	if err := p.channel.ExchangeDeclarePassive(
 		p.pt,
-		"topic",
+		p.exchangeKind,
 		true,
 		false,
 		false,
@@ -132,15 +139,20 @@ func NewConnection(pCfg *config.PublisherCfg) (*amqp.Connection, error) {
 }
 
 // NewPublisher creates a channel and declares the topic exchange.
-func NewPublisher(topic string, conn *amqp.Connection) (*amqp.Channel, error) {
+func NewPublisher(topic, exchangeKind string, conn *amqp.Connection) (*amqp.Channel, error) {
 	channel, err := conn.Channel()
 	if err != nil {
 		return nil, fmt.Errorf("open channel: %w", err)
 	}
 
+	if exchangeKind == "" {
+		_ = channel.Close()
+		return nil, fmt.Errorf("exchange kind is required")
+	}
+
 	if err = channel.ExchangeDeclare(
 		topic,
-		"topic",
+		exchangeKind,
 		true,
 		false,
 		false,


### PR DESCRIPTION
## Summary
- add required `publisher.exchange_kind` config for RabbitMQ
- pass exchange kind through RabbitMQ publisher factory
- use configured exchange kind for declare and passive health checks

Closes #50